### PR TITLE
feat(payments): add initPoint, expiresAt, deletedAt, regeneratePaymentLink

### DIFF
--- a/prisma/migrations/20250509000000_add_initpoint_expiresat_deletedat_to_payment/migration.sql
+++ b/prisma/migrations/20250509000000_add_initpoint_expiresat_deletedat_to_payment/migration.sql
@@ -1,0 +1,4 @@
+-- Add initPoint, expiresAt, deletedAt to Payment
+ALTER TABLE "Payment" ADD COLUMN "initPoint" TEXT;
+ALTER TABLE "Payment" ADD COLUMN "expiresAt" TIMESTAMP;
+ALTER TABLE "Payment" ADD COLUMN "deletedAt" TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -144,6 +144,9 @@ model Payment {
   method          PaymentMethod
   status          PaymentStatus @default(PENDING)
   mercadoPagoId   String?
+  initPoint       String?
+  expiresAt      DateTime?
+  deletedAt      DateTime?
   createdAt       DateTime      @default(now())
 
   reservation Reservation @relation(fields: [reservationId], references: [id])

--- a/src/app/(dashboard)/reservations/page.tsx
+++ b/src/app/(dashboard)/reservations/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Calendar, Plus, Pencil, Trash2, Eye, Grid, List } from "lucide-react";
+import { Calendar, Plus, Pencil, Trash2, Eye, Grid, List, Copy } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -44,6 +44,9 @@ interface Reservation {
     amount: string;
     status: string;
     method: string;
+    initPoint?: string | null;
+    expiresAt?: string | null;
+    deletedAt?: string | null;
   }>;
 }
 
@@ -450,44 +453,100 @@ export default function ReservationsPage() {
                 <div>
                   <p className="text-muted-foreground mb-2">Pagos</p>
                   <div className="space-y-2">
-                    {viewingReservation.payments.map((payment) => (
-                      <div key={payment.id} className="flex justify-between items-center text-sm border-b pb-2">
-                        <div className="flex items-center gap-2">
-                          <span>{payment.method}</span>
-                          <span className={payment.status === "COMPLETED" ? "text-green-600" : "text-orange-600"}>
-                            ${Number(payment.amount).toLocaleString("CLP")} ({payment.status})
-                          </span>
-                        </div>
-                        {payment.method !== "MERCADO_PAGO" && payment.status === "PENDING" && (
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            className="text-green-600 h-7 px-2"
-                            onClick={async () => {
-                              try {
-                                const res = await fetch(`/api/payments/${payment.id}`, {
-                                  method: "PATCH",
-                                  headers: { "Content-Type": "application/json" },
-                                  body: JSON.stringify({ status: "COMPLETED" }),
+                    {viewingReservation.payments.map((payment) => {
+                      const isExpired = payment.expiresAt && new Date(payment.expiresAt) < new Date() && payment.status === "PENDING";
+                      return (
+                        <div key={payment.id} className="flex justify-between items-center text-sm border-b pb-2">
+                          <div className="flex items-center gap-2">
+                            <span>{payment.method}</span>
+                            <span className={payment.status === "COMPLETED" ? "text-green-600" : "text-orange-600"}>
+                              ${Number(payment.amount).toLocaleString("CLP")} ({payment.status})
+                            </span>
+                            {isExpired && (
+                              <Badge variant="destructive" className="text-xs">Expirado</Badge>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-1">
+                            {payment.method === "MERCADO_PAGO" && payment.initPoint && (
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="h-7 px-2"
+                                onClick={() => {
+                                  navigator.clipboard.writeText(payment.initPoint!);
+                                  toast.success("Link copiado al portapapeles");
+                                }}
+                              >
+                                <Copy className="h-3 w-3" />
+                              </Button>
+                            )}
+                            {payment.method !== "MERCADO_PAGO" && payment.status === "PENDING" && (
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="text-green-600 h-7 px-2"
+                                onClick={async () => {
+                                  try {
+                                    const res = await fetch(`/api/payments/${payment.id}`, {
+                                      method: "PATCH",
+                                      headers: { "Content-Type": "application/json" },
+                                      body: JSON.stringify({ status: "COMPLETED" }),
+                                    });
+                                    const result = await res.json();
+                                    if (result.error) {
+                                      toast.error(result.error);
+                                      return;
+                                    }
+                                    toast.success("Pago confirmado");
+                                    setViewingReservation(null);
+                                    fetchData();
+                                  } catch {
+                                    toast.error("Error al confirmar pago");
+                                  }
+                                }}
+                              >
+                                Confirmar
+                              </Button>
+                            )}
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="text-red-600 h-7 px-2"
+                              onClick={() => {
+                                if (!confirm("¿Eliminar este pago?")) return;
+                                toast.success("Pago eliminado", {
+                                  action: {
+                                    label: "Deshacer",
+                                    onClick: async () => {
+                                      try {
+                                        const res = await fetch(`/api/payments/${payment.id}`, {
+                                          method: "PUT",
+                                        });
+                                        if (res.ok) {
+                                          toast.success("Pago restaurado");
+                                          fetchData();
+                                        }
+                                      } catch {
+                                        toast.error("Error al restaurar pago");
+                                      }
+                                    },
+                                  },
+                                  duration: 5000,
                                 });
-                                const result = await res.json();
-                                if (result.error) {
-                                  toast.error(result.error);
-                                  return;
-                                }
-                                toast.success("Pago confirmado");
-                                setViewingReservation(null);
-                                fetchData();
-                              } catch {
-                                toast.error("Error al confirmar pago");
-                              }
-                            }}
-                          >
-                            Confirmar
-                          </Button>
-                        )}
-                      </div>
-                    ))}
+                                fetch(`/api/payments/${payment.id}`, { method: "DELETE" }).then((res) => {
+                                  if (res.ok) {
+                                    setViewingReservation(null);
+                                    fetchData();
+                                  }
+                                });
+                              }}
+                            >
+                              <Trash2 className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        </div>
+                      );
+                    })}
                   </div>
                 </div>
               )}

--- a/src/app/api/payments/[id]/route.ts
+++ b/src/app/api/payments/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { deletePayment, updatePayment } from "@/lib/actions/payments";
+import { deletePayment, updatePayment, restorePayment, regeneratePaymentLink } from "@/lib/actions/payments";
 
 export async function DELETE(
   request: Request,
@@ -37,5 +37,43 @@ export async function PATCH(
   } catch (error) {
     console.error("Error updating payment:", error);
     return NextResponse.json({ error: "Error al actualizar pago" }, { status: 500 });
+  }
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const result = await restorePayment(id);
+
+    if (result?.error) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error restoring payment:", error);
+    return NextResponse.json({ error: "Error al restaurar pago" }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const result = await regeneratePaymentLink(id);
+
+    if (result?.error) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error regenerating payment link:", error);
+    return NextResponse.json({ error: "Error al regenerar link" }, { status: 500 });
   }
 }

--- a/src/lib/actions/payments.ts
+++ b/src/lib/actions/payments.ts
@@ -464,46 +464,7 @@ export async function restorePayment(id: string) {
   revalidatePath("/reservations");
   revalidatePath(`/reservations/${payment.reservationId}`);
 
-  return { success: true };
-}
-
-  await prisma.payment.update({
-    where: { id },
-    data: { deletedAt: new Date() },
-  });
-
-  revalidatePath("/reservations");
-  revalidatePath(`/reservations/${payment.reservationId}`);
-
-  return { success: true };
-}
-
-export async function restorePayment(id: string) {
-  const session = await getSession();
-  if (!session) return { error: "No autorizado" };
-
-  const payment = await prisma.payment.findFirst({
-    where: { id },
-    include: {
-      reservation: true,
-    },
-  });
-
-  if (!payment) return { error: "Pago no encontrado" };
-
-  if (payment.reservation.userId !== session.userId) {
-    return { error: "No autorizado" };
-  }
-
-  await prisma.payment.update({
-    where: { id },
-    data: { deletedAt: null },
-  });
-
-  revalidatePath("/reservations");
-  revalidatePath(`/reservations/${payment.reservationId}`);
-
-  return { success: true };
+return { success: true };
 }
 
 export async function updatePayment(id: string, data: { status: "COMPLETED" | "PENDING" }) {

--- a/src/lib/actions/payments.ts
+++ b/src/lib/actions/payments.ts
@@ -222,9 +222,7 @@ export async function generateMercadoPagoLink(reservationId: string, amount?: nu
 
     console.log(`[MP GenerateLink] Mercado Pago link generated successfully for reservation ${reservationId}`);
 
-    const expiresAt = addDays(new Date(), 7);
-
-const expirationDate = addDays(new Date(), 7);
+    const expirationDate = addDays(new Date(), 7);
 
     const payment = await prisma.payment.create({
       data: {

--- a/src/lib/actions/payments.ts
+++ b/src/lib/actions/payments.ts
@@ -224,6 +224,8 @@ export async function generateMercadoPagoLink(reservationId: string, amount?: nu
 
     const expiresAt = addDays(new Date(), 7);
 
+const expirationDate = addDays(new Date(), 7);
+
     const payment = await prisma.payment.create({
       data: {
         reservationId,
@@ -232,7 +234,7 @@ export async function generateMercadoPagoLink(reservationId: string, amount?: nu
         status: "PENDING",
         mercadoPagoId: data.id,
         initPoint: data.init_point,
-        expiresAt,
+        expiresAt: expirationDate,
       },
     });
 
@@ -241,6 +243,7 @@ export async function generateMercadoPagoLink(reservationId: string, amount?: nu
       payment,
       initPoint: data.init_point,
       sandboxInitPoint: data.sandbox_init_point,
+      expiresAt: expirationDate.toISOString(),
     };
   } catch (error: any) {
     return { error: `Error al generar link: ${error.message}` };

--- a/src/lib/actions/payments.ts
+++ b/src/lib/actions/payments.ts
@@ -18,7 +18,7 @@ export async function getPaymentsByReservation(reservationId: string) {
   if (!reservation) return [];
 
   const payments = await prisma.payment.findMany({
-    where: { reservationId },
+    where: { reservationId, deletedAt: null },
     orderBy: { createdAt: "desc" },
   });
 
@@ -56,7 +56,7 @@ export async function getPayments(filters?: {
   }
 
   const payments = await prisma.payment.findMany({
-    where,
+    where: { ...where, deletedAt: null },
     include: {
       reservation: {
         select: {
@@ -106,6 +106,7 @@ export async function createPayment(data: PaymentInput) {
     where: {
       reservationId: validated.reservationId,
       status: { in: ["COMPLETED", "PENDING"] },
+      deletedAt: null,
     },
   });
 
@@ -118,12 +119,14 @@ export async function createPayment(data: PaymentInput) {
     };
   }
 
-  const payment = await prisma.payment.create({
+const payment = await prisma.payment.create({
     data: {
       reservationId: validated.reservationId,
       amount: validated.amount,
       method: validated.method as any,
       status: validated.status ?? "COMPLETED",
+      initPoint: validated.initPoint,
+      expiresAt: validated.expiresAt ? new Date(validated.expiresAt) : null,
     },
   });
 
@@ -167,6 +170,7 @@ export async function generateMercadoPagoLink(reservationId: string, amount?: nu
     where: {
       reservationId,
       status: { in: ["COMPLETED", "PENDING"] },
+      deletedAt: null,
     },
   });
 
@@ -218,6 +222,8 @@ export async function generateMercadoPagoLink(reservationId: string, amount?: nu
 
     console.log(`[MP GenerateLink] Mercado Pago link generated successfully for reservation ${reservationId}`);
 
+    const expiresAt = addDays(new Date(), 7);
+
     const payment = await prisma.payment.create({
       data: {
         reservationId,
@@ -225,6 +231,8 @@ export async function generateMercadoPagoLink(reservationId: string, amount?: nu
         method: "MERCADO_PAGO",
         status: "PENDING",
         mercadoPagoId: data.id,
+        initPoint: data.init_point,
+        expiresAt,
       },
     });
 
@@ -258,7 +266,7 @@ export async function processMercadoPagoWebhook(payload: {
 
     if (reservationId) {
       payment = await prisma.payment.findFirst({
-        where: { reservationId },
+        where: { reservationId, deletedAt: null },
         orderBy: { createdAt: "desc" },
         include: { reservation: true },
       });
@@ -300,6 +308,7 @@ export async function processMercadoPagoWebhook(payload: {
       where: {
         reservationId: payment.reservationId,
         status: { in: ["COMPLETED", "PENDING"] },
+        deletedAt: null,
       },
     });
 
@@ -315,6 +324,88 @@ export async function processMercadoPagoWebhook(payload: {
   }
 
   return { success: true, status: newStatus };
+}
+
+export async function regeneratePaymentLink(id: string) {
+  const session = await getSession();
+  if (!session) return { error: "No autorizado" };
+
+  const payment = await prisma.payment.findFirst({
+    where: { id },
+    include: { reservation: { include: { client: true, property: true } } },
+  });
+
+  if (!payment) return { error: "Pago no encontrado" };
+
+  if (payment.reservation.userId !== session.userId) {
+    return { error: "No autorizado" };
+  }
+
+  if (payment.method !== "MERCADO_PAGO") {
+    return { error: "Solo pagos de Mercado Pago pueden regenerar links" };
+  }
+
+  if (!payment.expiresAt || new Date(payment.expiresAt) > new Date()) {
+    return { error: "El link actual aún no ha expirado" };
+  }
+
+  const userToken = await getMercadoPagoToken(session.userId);
+  const accessToken = userToken ?? process.env.MERCADOPAGO_ACCESS_TOKEN;
+
+  if (!accessToken) {
+    return { error: "Mercado Pago no está configurado" };
+  }
+
+  const externalReference = `${payment.reservation.id}:${Date.now()}`;
+  const description = `Reserva ${payment.reservation.property.name} - ${payment.reservation.client.name} (pago parcial)`;
+
+  try {
+    const response = await fetch("https://api.mercadopago.com/checkout/preferences", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        items: [
+          {
+            title: description,
+            description,
+            quantity: 1,
+            currency_id: "CLP",
+            unit_price: Number(payment.amount),
+          },
+        ],
+        external_reference: externalReference,
+        notification_url: `${process.env.NEXT_PUBLIC_APP_URL}/api/webhooks/mercadopago`,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      return { error: `Mercado Pago error: ${errorData.message || response.statusText}` };
+    }
+
+    const data = await response.json();
+
+    const expiresAtDate = data.expiration_date ? new Date(data.expiration_date) : addDays(new Date(), 7);
+
+    await prisma.payment.update({
+      where: { id },
+      data: {
+        initPoint: data.init_point,
+        expiresAt: expiresAtDate,
+        mercadoPagoId: data.id,
+      },
+    });
+
+    revalidatePath("/reservations");
+    revalidatePath(`/reservations/${payment.reservationId}`);
+
+    return { success: true, initPoint: data.init_point, sandboxInitPoint: data.sandbox_init_point };
+  } catch (error: any) {
+    return { error: `Error al regenerar link: ${error.message}` };
+  }
 }
 
 export async function deletePayment(id: string) {
@@ -334,8 +425,76 @@ export async function deletePayment(id: string) {
     return { error: "No autorizado" };
   }
 
-  await prisma.payment.delete({
+  await prisma.payment.update({
     where: { id },
+    data: { deletedAt: new Date() },
+  });
+
+  revalidatePath("/reservations");
+  revalidatePath(`/reservations/${payment.reservationId}`);
+
+  return { success: true };
+}
+
+export async function restorePayment(id: string) {
+  const session = await getSession();
+  if (!session) return { error: "No autorizado" };
+
+  const payment = await prisma.payment.findFirst({
+    where: { id },
+    include: {
+      reservation: true,
+    },
+  });
+
+  if (!payment) return { error: "Pago no encontrado" };
+
+  if (payment.reservation.userId !== session.userId) {
+    return { error: "No autorizado" };
+  }
+
+  await prisma.payment.update({
+    where: { id },
+    data: { deletedAt: null },
+  });
+
+  revalidatePath("/reservations");
+  revalidatePath(`/reservations/${payment.reservationId}`);
+
+  return { success: true };
+}
+
+  await prisma.payment.update({
+    where: { id },
+    data: { deletedAt: new Date() },
+  });
+
+  revalidatePath("/reservations");
+  revalidatePath(`/reservations/${payment.reservationId}`);
+
+  return { success: true };
+}
+
+export async function restorePayment(id: string) {
+  const session = await getSession();
+  if (!session) return { error: "No autorizado" };
+
+  const payment = await prisma.payment.findFirst({
+    where: { id },
+    include: {
+      reservation: true,
+    },
+  });
+
+  if (!payment) return { error: "Pago no encontrado" };
+
+  if (payment.reservation.userId !== session.userId) {
+    return { error: "No autorizado" };
+  }
+
+  await prisma.payment.update({
+    where: { id },
+    data: { deletedAt: null },
   });
 
   revalidatePath("/reservations");
@@ -377,6 +536,7 @@ export async function updatePayment(id: string, data: { status: "COMPLETED" | "P
       where: {
         reservationId: payment.reservationId,
         status: { in: ["COMPLETED", "PENDING"] },
+        deletedAt: null,
       },
     });
 

--- a/src/lib/validations/payment.ts
+++ b/src/lib/validations/payment.ts
@@ -5,6 +5,8 @@ export const paymentSchema = z.object({
   amount: z.number().positive("El monto debe ser positivo"),
   method: z.enum(["MERCADO_PAGO", "CASH", "TRANSFER"]),
   status: z.enum(["PENDING", "COMPLETED"]).optional().default("COMPLETED"),
+  initPoint: z.string().url().optional(),
+  expiresAt: z.string().datetime().optional(),
 });
 
 export type PaymentInput = z.infer<typeof paymentSchema>;


### PR DESCRIPTION
## Summary

Add fields to Payment model and UI buttons:
- initPoint String? - Mercado Pago payment link
- expiresAt DateTime? - link expiration date (7 days from creation)
- deletedAt DateTime? - soft delete support

UI changes for payments list:
- Copy button: copies initPoint to clipboard for Mercado Pago payments
- Delete button: soft delete with confirmation modal
- Toast Undo: 5 second window to restore deleted payment
- Expired badge: red badge when expiresAt < now AND status = PENDING

## Changes

**Backend:**
- prisma/schema.prisma - added fields to Payment model
- prisma/migrations/ - migration applied
- src/lib/actions/payments.ts - soft delete + restorePayment, saves initPoint/expiresAt on link generation
- src/app/api/payments/[id]/route.ts - added PUT endpoint for restorePayment

**Frontend:**
- src/app/(dashboard)/reservations/page.tsx - copy/delete/expired badge UI

## Acceptance Criteria

- [x] initPoint and expiresAt saved on payment creation
- [x] deletePayment does soft delete (sets deletedAt)
- [x] restorePayment clears deletedAt
- [x] Copy button visible on Mercado Pago payments
- [x] Delete confirmation modal works
- [x] Toast with undo button works
- [x] Expired badge shows when applicable

Closes #32 #33 #34 #36