### PR TITLE
fix(primitives): apply rectangular radius to Badge (closes #148)

### DIFF
--- a/src/components/ui/__tests__/badge.test.tsx
+++ b/src/components/ui/__tests__/badge.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Badge } from "../badge";
+
+describe("Badge radius (ADR-0016)", () => {
+  it("uses a rectangular chip radius (rounded-md) instead of a pill radius", () => {
+    render(<Badge data-testid="badge">Activo</Badge>);
+
+    const badge = screen.getByTestId("badge");
+    const className = badge.className;
+
+    expect(className).toContain("rounded-md");
+  });
+
+  it("does not use the pill-style rounded-4xl radius", () => {
+    render(<Badge data-testid="badge">Activo</Badge>);
+
+    const badge = screen.getByTestId("badge");
+    const tokens = badge.className.split(/\s+/);
+
+    expect(tokens).not.toContain("rounded-4xl");
+  });
+
+  it("does not use rounded-full on the badge body", () => {
+    render(<Badge data-testid="badge">Activo</Badge>);
+
+    const badge = screen.getByTestId("badge");
+    const tokens = badge.className.split(/\s+/);
+
+    expect(tokens).not.toContain("rounded-full");
+  });
+});

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-md border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary

Changes ounded-4xl to ounded-md in src/components/ui/badge.tsx per ADR-0016.

- Badge now uses ounded-md (compact chip radius) instead of pill radius
- 3 new tests verify rectangular shape

## Related

Closes #148