### PR TITLE
fix(calendar): normalize control radii per ADR-0016 (closes #149)

### DIFF
--- a/src/components/calendar/__tests__/calendar-grid.test.tsx
+++ b/src/components/calendar/__tests__/calendar-grid.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import {
+  getContinuationRadiusClass,
+  CalendarGrid,
+  type WeekReservation,
+} from "../calendar-grid";
+
+function formatYmd(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function makeWr(
+  overrides: Partial<WeekReservation> = {}
+): WeekReservation {
+  return {
+    res: {
+      id: "r1",
+      startDate: "2025-01-01",
+      endDate: "2025-01-07",
+      status: "CONFIRMED",
+      billingType: "DAILY",
+      totalPrice: 100,
+      property: { id: "p1", name: "Casa", color: "#6366F1" },
+      client: { name: "Juan" },
+    },
+    startCol: 0,
+    span: 7,
+    lane: 0,
+    continuesFromPreviousWeek: false,
+    continuesIntoNextWeek: false,
+    ...overrides,
+  };
+}
+
+describe("getContinuationRadiusClass", () => {
+  it("uses a rectangular radius when the reservation does not continue into another week", () => {
+    const cls = getContinuationRadiusClass(makeWr());
+    expect(cls).not.toMatch(/rounded-full/);
+    expect(cls).toMatch(/rounded-(md|lg)/);
+  });
+
+  it("uses a rectangular right edge when it continues from the previous week", () => {
+    const cls = getContinuationRadiusClass(
+      makeWr({ continuesFromPreviousWeek: true })
+    );
+    expect(cls).not.toMatch(/rounded-full/);
+    expect(cls).toMatch(/rounded-l-/);
+    expect(cls).toMatch(/rounded-r-/);
+  });
+
+  it("uses a rectangular left edge when it continues into the next week", () => {
+    const cls = getContinuationRadiusClass(
+      makeWr({ continuesIntoNextWeek: true })
+    );
+    expect(cls).not.toMatch(/rounded-full/);
+    expect(cls).toMatch(/rounded-l-/);
+    expect(cls).toMatch(/rounded-r-/);
+  });
+
+  it("uses the smallest rectangular radius when it continues on both sides", () => {
+    const cls = getContinuationRadiusClass(
+      makeWr({
+        continuesFromPreviousWeek: true,
+        continuesIntoNextWeek: true,
+      })
+    );
+    expect(cls).not.toMatch(/rounded-full/);
+    expect(cls).toMatch(/rounded/);
+  });
+});
+
+describe("CalendarGrid controls", () => {
+  function getNavSegment() {
+    const hoyButton = screen.getByRole("button", { name: "Hoy" });
+    return hoyButton.parentElement as HTMLElement;
+  }
+
+  it("renders the 'Hoy' button with a rectangular radius and not rounded-full", () => {
+    render(<CalendarGrid reservations={[]} />);
+    const hoyButton = screen.getByRole("button", { name: "Hoy" });
+    const cls = hoyButton.className;
+    expect(cls).not.toMatch(/rounded-full/);
+    expect(cls).toMatch(/rounded-(md|lg)/);
+  });
+
+  it("renders the previous month icon button with a rectangular radius", () => {
+    render(<CalendarGrid reservations={[]} />);
+    const segment = getNavSegment();
+    const buttons = within(segment).getAllByRole("button");
+    const prevButton = buttons[0];
+    expect(prevButton).toBeDefined();
+    const cls = prevButton.className;
+    expect(cls).not.toMatch(/rounded-full/);
+    expect(cls).toMatch(/rounded-(md|lg)/);
+  });
+
+  it("renders the next month icon button with a rectangular radius", () => {
+    render(<CalendarGrid reservations={[]} />);
+    const segment = getNavSegment();
+    const buttons = within(segment).getAllByRole("button");
+    const nextButton = buttons[buttons.length - 1];
+    expect(nextButton).toBeDefined();
+    const cls = nextButton.className;
+    expect(cls).not.toMatch(/rounded-full/);
+    expect(cls).toMatch(/rounded-(md|lg)/);
+  });
+
+  it("renders the 'Expandir todas' button with a rectangular radius when weeks are expandable", () => {
+    const now = new Date();
+    const dayOfWeek = now.getDay();
+    const monday = new Date(now);
+    monday.setDate(now.getDate() - ((dayOfWeek + 6) % 7));
+    const iso = formatYmd(monday);
+    const manyReservations = [0, 1, 2].map((i) => ({
+      id: `r${i}`,
+      startDate: iso,
+      endDate: iso,
+      status: "CONFIRMED",
+      billingType: "DAILY",
+      totalPrice: 100,
+      property: { id: "p1", name: "Casa", color: "#6366F1" },
+      client: { name: `Cliente ${i}` },
+    }));
+    const { container } = render(
+      <CalendarGrid reservations={manyReservations} />
+    );
+    const buttons = Array.from(container.querySelectorAll("button"));
+    const expandAll = buttons.find((b) =>
+      b.textContent?.includes("Expandir todas")
+    );
+    if (!expandAll) {
+      const titles = Array.from(container.querySelectorAll("[title]")).map(
+        (el) => el.getAttribute("title")
+      );
+      const allText = container.textContent || "";
+      throw new Error(
+        `No 'Expandir todas' button found. Buttons: ${buttons.length}, titles: ${JSON.stringify(titles)}, has 'Expandir' in text: ${allText.includes("Expandir")}`
+      );
+    }
+    const cls = expandAll.className;
+    expect(cls).not.toMatch(/rounded-full/);
+    expect(cls).toMatch(/rounded-(md|lg)/);
+  });
+
+  it("renders the per-week 'Expandir' button with a rectangular radius when lanes overflow", () => {
+    const now = new Date();
+    const dayOfWeek = now.getDay();
+    const monday = new Date(now);
+    monday.setDate(now.getDate() - ((dayOfWeek + 6) % 7));
+    const iso = formatYmd(monday);
+    const manyReservations = [0, 1, 2].map((i) => ({
+      id: `r${i}`,
+      startDate: iso,
+      endDate: iso,
+      status: "CONFIRMED",
+      billingType: "DAILY",
+      totalPrice: 100,
+      property: { id: "p1", name: "Casa", color: "#6366F1" },
+      client: { name: `Cliente ${i}` },
+    }));
+    const { container } = render(
+      <CalendarGrid reservations={manyReservations} />
+    );
+    const buttons = Array.from(container.querySelectorAll("button"));
+    const expandBtn = buttons.find(
+      (b) =>
+        b.className.includes("absolute bottom-1") ||
+        b.className.includes("absolute bottom-1.5")
+    );
+    expect(expandBtn).toBeDefined();
+    const cls = expandBtn!.className;
+    expect(cls).not.toMatch(/rounded-full/);
+    expect(cls).toMatch(/rounded-(md|lg)/);
+  });
+
+  it("renders the 'Hoy' label overlay chip on the current day with a rectangular radius", () => {
+    const { container } = render(<CalendarGrid reservations={[]} />);
+    const spans = Array.from(container.querySelectorAll("span"));
+    const hoyChip = spans.find(
+      (s) => s.textContent?.trim() === "Hoy" && s.className.includes("uppercase")
+    );
+    expect(hoyChip).toBeDefined();
+    const cls = hoyChip!.className;
+    expect(cls).not.toMatch(/rounded-full/);
+    expect(cls).toMatch(/rounded/);
+  });
+
+  it("keeps the current-day date marker circular (rounded-full)", () => {
+    const { container } = render(<CalendarGrid reservations={[]} />);
+    const divs = Array.from(container.querySelectorAll("div"));
+    const dayMarker = divs.find(
+      (d) =>
+        d.className.includes("rounded-full") &&
+        d.className.includes("bg-primary") &&
+        d.className.includes("text-primary-foreground")
+    );
+    expect(dayMarker).toBeDefined();
+  });
+});

--- a/src/components/calendar/__tests__/calendar-grid.test.tsx
+++ b/src/components/calendar/__tests__/calendar-grid.test.tsx
@@ -79,15 +79,16 @@ describe("CalendarGrid controls", () => {
     return hoyButton.parentElement as HTMLElement;
   }
 
-  it("renders the 'Hoy' button with a rectangular radius and not rounded-full", () => {
+  it("renders the 'Hoy' button with rounded-lg (ADR-0016 primary control)", () => {
     render(<CalendarGrid reservations={[]} />);
     const hoyButton = screen.getByRole("button", { name: "Hoy" });
     const cls = hoyButton.className;
     expect(cls).not.toMatch(/rounded-full/);
-    expect(cls).toMatch(/rounded-(md|lg)/);
+    expect(cls).not.toMatch(/\brounded-md\b/);
+    expect(cls).toMatch(/\brounded-lg\b/);
   });
 
-  it("renders the previous month icon button with a rectangular radius", () => {
+  it("renders the previous month icon button with rounded-lg (ADR-0016 primary control)", () => {
     render(<CalendarGrid reservations={[]} />);
     const segment = getNavSegment();
     const buttons = within(segment).getAllByRole("button");
@@ -95,10 +96,11 @@ describe("CalendarGrid controls", () => {
     expect(prevButton).toBeDefined();
     const cls = prevButton.className;
     expect(cls).not.toMatch(/rounded-full/);
-    expect(cls).toMatch(/rounded-(md|lg)/);
+    expect(cls).not.toMatch(/\brounded-md\b/);
+    expect(cls).toMatch(/\brounded-lg\b/);
   });
 
-  it("renders the next month icon button with a rectangular radius", () => {
+  it("renders the next month icon button with rounded-lg (ADR-0016 primary control)", () => {
     render(<CalendarGrid reservations={[]} />);
     const segment = getNavSegment();
     const buttons = within(segment).getAllByRole("button");
@@ -106,10 +108,11 @@ describe("CalendarGrid controls", () => {
     expect(nextButton).toBeDefined();
     const cls = nextButton.className;
     expect(cls).not.toMatch(/rounded-full/);
-    expect(cls).toMatch(/rounded-(md|lg)/);
+    expect(cls).not.toMatch(/\brounded-md\b/);
+    expect(cls).toMatch(/\brounded-lg\b/);
   });
 
-  it("renders the 'Expandir todas' button with a rectangular radius when weeks are expandable", () => {
+  it("renders the 'Expandir todas' button with rounded-lg (ADR-0016 primary control) when weeks are expandable", () => {
     const now = new Date();
     const dayOfWeek = now.getDay();
     const monday = new Date(now);
@@ -143,7 +146,8 @@ describe("CalendarGrid controls", () => {
     }
     const cls = expandAll.className;
     expect(cls).not.toMatch(/rounded-full/);
-    expect(cls).toMatch(/rounded-(md|lg)/);
+    expect(cls).not.toMatch(/\brounded-md\b/);
+    expect(cls).toMatch(/\brounded-lg\b/);
   });
 
   it("renders the per-week 'Expandir' button with a rectangular radius when lanes overflow", () => {

--- a/src/components/calendar/__tests__/calendar-timeline.test.tsx
+++ b/src/components/calendar/__tests__/calendar-timeline.test.tsx
@@ -97,7 +97,7 @@ describe("CalendarTimeline navigation segment", () => {
     expect(container).toBeDefined();
   });
 
-  it("renders the 'Hoy' button with a rectangular radius", () => {
+  it("renders the 'Hoy' button with rounded-lg (ADR-0016 primary control)", () => {
     render(
       <CalendarTimeline
         reservations={[]}
@@ -109,10 +109,11 @@ describe("CalendarTimeline navigation segment", () => {
     const hoyButton = screen.getByRole("button", { name: "Hoy" });
     const cls = hoyButton.className;
     expect(cls).not.toMatch(/rounded-full/);
-    expect(cls).toMatch(/rounded-(md|lg)/);
+    expect(cls).not.toMatch(/\brounded-md\b/);
+    expect(cls).toMatch(/\brounded-lg\b/);
   });
 
-  it("renders the prev/next icon buttons with a rectangular radius", () => {
+  it("renders the prev/next icon buttons with rounded-lg (ADR-0016 primary control)", () => {
     const { container } = render(
       <CalendarTimeline
         reservations={[]}
@@ -130,7 +131,8 @@ describe("CalendarTimeline navigation segment", () => {
     expect(iconButtons.length).toBe(2);
     for (const btn of iconButtons) {
       expect(btn.className).not.toMatch(/rounded-full/);
-      expect(btn.className).toMatch(/rounded-(md|lg)/);
+      expect(btn.className).not.toMatch(/\brounded-md\b/);
+      expect(btn.className).toMatch(/\brounded-lg\b/);
     }
     expect(container).toBeDefined();
   });

--- a/src/components/calendar/__tests__/calendar-timeline.test.tsx
+++ b/src/components/calendar/__tests__/calendar-timeline.test.tsx
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  CalendarTimeline,
+  CalendarMonthGrid,
+  ReservationDetailDialog,
+} from "../calendar-timeline";
+
+const baseProperty = {
+  id: "p1",
+  name: "Casa Norte",
+  color: "#6366F1",
+};
+
+const baseClient = {
+  id: "c1",
+  name: "Juan Pérez",
+  email: "juan@example.com",
+};
+
+const baseReservation = {
+  id: "r1",
+  propertyId: "p1",
+  clientId: "c1",
+  startDate: "2025-01-10",
+  endDate: "2025-01-15",
+  billingType: "DAILY",
+  unitsBooked: 1,
+  totalPrice: "300000",
+  status: "CONFIRMED",
+  bookingAirbnb: false,
+  notes: null,
+  property: baseProperty,
+  client: baseClient,
+  payments: [],
+};
+
+const currentMonth = new Date("2025-01-15T00:00:00");
+
+function makeRes(overrides: Partial<typeof baseReservation> = {}) {
+  return { ...baseReservation, ...overrides };
+}
+
+describe("CalendarTimeline reservation bar", () => {
+  it("renders the reservation bar with a rectangular radius and not rounded-full", () => {
+    const { container } = render(
+      <CalendarTimeline
+        reservations={[makeRes()]}
+        currentMonth={currentMonth}
+        onSelectReservation={() => {}}
+        onMonthChange={() => {}}
+      />
+    );
+    const reservationBar = container.querySelector(
+      "button[title]"
+    ) as HTMLElement | null;
+    expect(reservationBar).toBeTruthy();
+    const cls = reservationBar!.className;
+    expect(cls).not.toMatch(/rounded-full/);
+    expect(cls).toMatch(/rounded-(md|lg|sm)/);
+  });
+
+  it("renders the inner 'n' chip with a small rectangular radius and not rounded-full", () => {
+    const { container } = render(
+      <CalendarTimeline
+        reservations={[makeRes()]}
+        currentMonth={currentMonth}
+        onSelectReservation={() => {}}
+        onMonthChange={() => {}}
+      />
+    );
+    const spans = Array.from(container.querySelectorAll("span"));
+    const nightChip = spans.find((s) =>
+      /^\d+n$/.test(s.textContent?.trim() || "")
+    );
+    expect(nightChip).toBeDefined();
+    const cls = nightChip!.className;
+    expect(cls).not.toMatch(/rounded-full/);
+    expect(cls).toMatch(/rounded-/);
+  });
+});
+
+describe("CalendarTimeline navigation segment", () => {
+  it("renders the nav segment wrapper with a rectangular radius", () => {
+    const { container } = render(
+      <CalendarTimeline
+        reservations={[]}
+        currentMonth={currentMonth}
+        onSelectReservation={() => {}}
+        onMonthChange={() => {}}
+      />
+    );
+    const hoyButton = screen.getByRole("button", { name: "Hoy" });
+    const wrapper = hoyButton.parentElement as HTMLElement;
+    expect(wrapper.className).not.toMatch(/rounded-full/);
+    expect(wrapper.className).toMatch(/rounded-(md|lg)/);
+    expect(container).toBeDefined();
+  });
+
+  it("renders the 'Hoy' button with a rectangular radius", () => {
+    render(
+      <CalendarTimeline
+        reservations={[]}
+        currentMonth={currentMonth}
+        onSelectReservation={() => {}}
+        onMonthChange={() => {}}
+      />
+    );
+    const hoyButton = screen.getByRole("button", { name: "Hoy" });
+    const cls = hoyButton.className;
+    expect(cls).not.toMatch(/rounded-full/);
+    expect(cls).toMatch(/rounded-(md|lg)/);
+  });
+
+  it("renders the prev/next icon buttons with a rectangular radius", () => {
+    const { container } = render(
+      <CalendarTimeline
+        reservations={[]}
+        currentMonth={currentMonth}
+        onSelectReservation={() => {}}
+        onMonthChange={() => {}}
+      />
+    );
+    const hoyButton = screen.getByRole("button", { name: "Hoy" });
+    const wrapper = hoyButton.parentElement as HTMLElement;
+    const buttons = Array.from(wrapper.querySelectorAll("button"));
+    const iconButtons = buttons.filter(
+      (b) => b.querySelector("svg") && b.textContent?.trim() === ""
+    );
+    expect(iconButtons.length).toBe(2);
+    for (const btn of iconButtons) {
+      expect(btn.className).not.toMatch(/rounded-full/);
+      expect(btn.className).toMatch(/rounded-(md|lg)/);
+    }
+    expect(container).toBeDefined();
+  });
+});
+
+describe("CalendarMonthGrid navigation", () => {
+  it("renders the 'Hoy' button with a rectangular radius", () => {
+    render(
+      <CalendarMonthGrid
+        reservations={[]}
+        currentMonth={currentMonth}
+        onSelectReservation={() => {}}
+        onMonthChange={() => {}}
+      />
+    );
+    const hoyButton = screen.getByRole("button", { name: "Hoy" });
+    const cls = hoyButton.className;
+    expect(cls).not.toMatch(/rounded-full/);
+  });
+
+  it("renders the prev/next icon buttons without rounded-full", () => {
+    const { container } = render(
+      <CalendarMonthGrid
+        reservations={[]}
+        currentMonth={currentMonth}
+        onSelectReservation={() => {}}
+        onMonthChange={() => {}}
+      />
+    );
+    const allButtons = Array.from(container.querySelectorAll("button"));
+    const iconButtons = allButtons.filter(
+      (b) => b.querySelector("svg") && b.textContent?.trim() === ""
+    );
+    expect(iconButtons.length).toBe(2);
+    for (const btn of iconButtons) {
+      expect(btn.className).not.toMatch(/rounded-full/);
+    }
+  });
+});
+
+describe("ReservationDetailDialog pills", () => {
+  function renderDialog(overrides: Partial<typeof baseReservation> = {}) {
+    return render(
+      <ReservationDetailDialog
+        reservation={makeRes(overrides)}
+        onClose={() => {}}
+      />
+    );
+  }
+
+  it("renders the billing-type pill (DAILY) with a rectangular radius", () => {
+    renderDialog({ billingType: "DAILY" });
+    const dailyPill = screen
+      .getByText("Tarifa diaria")
+      .closest("div") as HTMLElement | null;
+    expect(dailyPill).toBeTruthy();
+    expect(dailyPill!.className).not.toMatch(/rounded-full/);
+    expect(dailyPill!.className).toMatch(/rounded/);
+  });
+
+  it("renders the billing-type pill (MONTHLY) with a rectangular radius", () => {
+    renderDialog({ billingType: "MONTHLY" });
+    const monthlyPill = screen
+      .getByText("Tarifa mensual")
+      .closest("div") as HTMLElement | null;
+    expect(monthlyPill).toBeTruthy();
+    expect(monthlyPill!.className).not.toMatch(/rounded-full/);
+    expect(monthlyPill!.className).toMatch(/rounded/);
+  });
+
+  it("renders the booking-source pill (Airbnb) with a rectangular radius", () => {
+    renderDialog({ bookingAirbnb: true });
+    const airbnbPill = screen
+      .getByText("Booking Airbnb")
+      .closest("div") as HTMLElement | null;
+    expect(airbnbPill).toBeTruthy();
+    expect(airbnbPill!.className).not.toMatch(/rounded-full/);
+    expect(airbnbPill!.className).toMatch(/rounded/);
+  });
+
+  it("renders the booking-source pill (Direct) with a rectangular radius", () => {
+    renderDialog({ bookingAirbnb: false });
+    const directPill = screen
+      .getByText("Directo")
+      .closest("div") as HTMLElement | null;
+    expect(directPill).toBeTruthy();
+    expect(directPill!.className).not.toMatch(/rounded-full/);
+    expect(directPill!.className).toMatch(/rounded/);
+  });
+});

--- a/src/components/calendar/calendar-grid.tsx
+++ b/src/components/calendar/calendar-grid.tsx
@@ -234,7 +234,7 @@ export function CalendarGrid({
           <Button
             variant="ghost"
             size="icon"
-            className="h-7 w-7 rounded-md sm:h-8 sm:w-8"
+            className="h-7 w-7 rounded-lg sm:h-8 sm:w-8"
             onClick={() => navigateMonth("prev")}
           >
             <ChevronLeft className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
@@ -242,7 +242,7 @@ export function CalendarGrid({
           <Button
             variant="secondary"
             size="sm"
-            className="h-7 rounded-md px-2.5 text-xs sm:h-8 sm:px-4"
+            className="h-7 rounded-lg px-2.5 text-xs sm:h-8 sm:px-4"
             onClick={() => setCurrentDate(new Date())}
           >
             Hoy
@@ -250,7 +250,7 @@ export function CalendarGrid({
           <Button
             variant="ghost"
             size="icon"
-            className="h-7 w-7 rounded-md sm:h-8 sm:w-8"
+            className="h-7 w-7 rounded-lg sm:h-8 sm:w-8"
             onClick={() => navigateMonth("next")}
           >
             <ChevronRight className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
@@ -263,7 +263,7 @@ export function CalendarGrid({
                 type="button"
                 variant="outline"
                 size="sm"
-                className="h-8 rounded-md px-3 text-xs"
+                className="h-8 rounded-lg px-3 text-xs"
                 onClick={toggleAllExpandableWeeks}
               >
                 {allExpandableWeeksExpanded ? "Colapsar todas" : "Expandir todas"}

--- a/src/components/calendar/calendar-grid.tsx
+++ b/src/components/calendar/calendar-grid.tsx
@@ -59,7 +59,7 @@ function getWeeks(days: Date[]): Date[][] {
   return weeks;
 }
 
-interface WeekReservation {
+export interface WeekReservation {
   res: CalendarReservation;
   startCol: number;
   span: number;
@@ -68,20 +68,20 @@ interface WeekReservation {
   continuesIntoNextWeek: boolean;
 }
 
-function getContinuationRadiusClass(wr: WeekReservation): string {
+export function getContinuationRadiusClass(wr: WeekReservation): string {
   if (wr.continuesFromPreviousWeek && wr.continuesIntoNextWeek) {
     return "rounded-sm";
   }
 
   if (wr.continuesFromPreviousWeek) {
-    return "rounded-l-sm rounded-r-full";
+    return "rounded-l-sm rounded-r-md";
   }
 
   if (wr.continuesIntoNextWeek) {
-    return "rounded-l-full rounded-r-sm";
+    return "rounded-l-md rounded-r-sm";
   }
 
-  return "rounded-full";
+  return "rounded-md";
 }
 
 function assignLanes(weekReservations: WeekReservation[]): WeekReservation[] {
@@ -230,11 +230,11 @@ export function CalendarGrid({
             {format(currentDate, "MMMM yyyy", { locale: es })}
           </h2>
         </div>
-        <div className="flex w-fit items-center gap-1 rounded-full border bg-background/80 p-0.5 shadow-sm sm:gap-2 sm:p-1 lg:justify-self-center">
+        <div className="flex w-fit items-center gap-1 rounded-lg border bg-background/80 p-0.5 shadow-sm sm:gap-2 sm:p-1 lg:justify-self-center">
           <Button
             variant="ghost"
             size="icon"
-            className="h-7 w-7 rounded-full sm:h-8 sm:w-8"
+            className="h-7 w-7 rounded-md sm:h-8 sm:w-8"
             onClick={() => navigateMonth("prev")}
           >
             <ChevronLeft className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
@@ -242,7 +242,7 @@ export function CalendarGrid({
           <Button
             variant="secondary"
             size="sm"
-            className="h-7 rounded-full px-2.5 text-xs sm:h-8 sm:px-4"
+            className="h-7 rounded-md px-2.5 text-xs sm:h-8 sm:px-4"
             onClick={() => setCurrentDate(new Date())}
           >
             Hoy
@@ -250,7 +250,7 @@ export function CalendarGrid({
           <Button
             variant="ghost"
             size="icon"
-            className="h-7 w-7 rounded-full sm:h-8 sm:w-8"
+            className="h-7 w-7 rounded-md sm:h-8 sm:w-8"
             onClick={() => navigateMonth("next")}
           >
             <ChevronRight className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
@@ -263,7 +263,7 @@ export function CalendarGrid({
                 type="button"
                 variant="outline"
                 size="sm"
-                className="h-8 rounded-full px-3 text-xs"
+                className="h-8 rounded-md px-3 text-xs"
                 onClick={toggleAllExpandableWeeks}
               >
                 {allExpandableWeeksExpanded ? "Colapsar todas" : "Expandir todas"}
@@ -345,7 +345,7 @@ export function CalendarGrid({
                         {format(day, "d")}
                       </div>
                       {isToday && (
-                        <span className="hidden rounded-full bg-primary/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-primary md:inline-flex">
+                        <span className="hidden rounded-md bg-primary/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-primary md:inline-flex">
                           Hoy
                         </span>
                       )}
@@ -435,7 +435,7 @@ export function CalendarGrid({
                     event.stopPropagation();
                     toggleExpandedWeek(weekIndex);
                   }}
-                  className="absolute bottom-1 left-1 z-20 flex items-center gap-1 rounded-full border border-border/50 bg-background/90 px-1.5 py-0.5 text-[9px] font-medium text-muted-foreground backdrop-blur-sm transition-all hover:bg-muted hover:text-foreground sm:bottom-1.5 sm:left-1.5 sm:px-2 sm:text-[10px]"
+                  className="absolute bottom-1 left-1 z-20 flex items-center gap-1 rounded-md border border-border/50 bg-background/90 px-1.5 py-0.5 text-[9px] font-medium text-muted-foreground backdrop-blur-sm transition-all hover:bg-muted hover:text-foreground sm:bottom-1.5 sm:left-1.5 sm:px-2 sm:text-[10px]"
                 >
                   {isExpanded ? (
                     <>

--- a/src/components/calendar/calendar-timeline.tsx
+++ b/src/components/calendar/calendar-timeline.tsx
@@ -264,14 +264,14 @@ export function CalendarTimeline({ reservations, currentMonth, onSelectReservati
             {format(currentMonth, "MMMM yyyy", { locale: es })}
           </h2>
         </div>
-        <div className="flex w-fit items-center gap-2 rounded-full border bg-background/80 p-1 shadow-sm lg:justify-self-center">
-          <Button variant="ghost" size="icon" className="h-8 w-8 rounded-full" onClick={() => onMonthChange(subMonths(currentMonth, 1))}>
+        <div className="flex w-fit items-center gap-2 rounded-lg border bg-background/80 p-1 shadow-sm lg:justify-self-center">
+          <Button variant="ghost" size="icon" className="h-8 w-8 rounded-md" onClick={() => onMonthChange(subMonths(currentMonth, 1))}>
             <ChevronLeft className="h-4 w-4" />
           </Button>
-          <Button variant="secondary" size="sm" className="h-8 rounded-full px-4" onClick={() => onMonthChange(new Date())}>
+          <Button variant="secondary" size="sm" className="h-8 rounded-md px-4" onClick={() => onMonthChange(new Date())}>
             Hoy
           </Button>
-          <Button variant="ghost" size="icon" className="h-8 w-8 rounded-full" onClick={() => onMonthChange(addMonths(currentMonth, 1))}>
+          <Button variant="ghost" size="icon" className="h-8 w-8 rounded-md" onClick={() => onMonthChange(addMonths(currentMonth, 1))}>
             <ChevronRight className="h-4 w-4" />
           </Button>
         </div>
@@ -361,7 +361,7 @@ export function CalendarTimeline({ reservations, currentMonth, onSelectReservati
                         <button
                           key={res.id}
                           onClick={() => onSelectReservation(res.id)}
-                          className={`group absolute flex h-8 items-center gap-2 overflow-hidden rounded-full border px-3 text-left text-xs shadow-sm transition-all hover:z-20 hover:-translate-y-0.5 hover:shadow-lg focus-visible:z-30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                          className={`group absolute flex h-8 items-center gap-2 overflow-hidden rounded-md border px-3 text-left text-xs shadow-sm transition-all hover:z-20 hover:-translate-y-0.5 hover:shadow-lg focus-visible:z-30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
                             isCancelled
                               ? "border-border bg-muted text-muted-foreground line-through"
                               : ended
@@ -378,7 +378,7 @@ export function CalendarTimeline({ reservations, currentMonth, onSelectReservati
                         >
                           <StatusIcon className="h-3.5 w-3.5 shrink-0 opacity-90" />
                           <span className="min-w-0 flex-1 truncate font-semibold">{res.client.name}</span>
-                          <span className="hidden shrink-0 rounded-full bg-black/10 px-1.5 py-0.5 font-medium sm:inline-flex">
+                          <span className="hidden shrink-0 rounded-sm bg-black/10 px-1.5 py-0.5 font-medium sm:inline-flex">
                             {getNights(res.startDate, res.endDate)}n
                           </span>
                         </button>
@@ -631,14 +631,14 @@ export function ReservationDetailDialog({ reservation, onClose }: {
           )}
 
           <div className="flex items-center gap-4 text-sm">
-            <div className={`px-3 py-1.5 rounded-full text-xs font-medium ${reservation.billingType === "DAILY" ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400" : "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400"}`}>
+            <div className={`px-3 py-1.5 rounded-md text-xs font-medium ${reservation.billingType === "DAILY" ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400" : "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400"}`}>
               {reservation.billingType === "DAILY" ? "Tarifa diaria" : "Tarifa mensual"}
             </div>
-            <div className={`px-3 py-1.5 rounded-full text-xs font-medium ${reservation.bookingAirbnb ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400" : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"}`}>
+            <div className={`px-3 py-1.5 rounded-md text-xs font-medium ${reservation.bookingAirbnb ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400" : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"}`}>
               {reservation.bookingAirbnb ? "Booking Airbnb" : "Directo"}
             </div>
             {reservation.unitsBooked > 1 && (
-              <div className="px-3 py-1.5 rounded-full text-xs font-medium bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+              <div className="px-3 py-1.5 rounded-md text-xs font-medium bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
                 {reservation.unitsBooked} unidades
               </div>
             )}

--- a/src/components/calendar/calendar-timeline.tsx
+++ b/src/components/calendar/calendar-timeline.tsx
@@ -265,13 +265,13 @@ export function CalendarTimeline({ reservations, currentMonth, onSelectReservati
           </h2>
         </div>
         <div className="flex w-fit items-center gap-2 rounded-lg border bg-background/80 p-1 shadow-sm lg:justify-self-center">
-          <Button variant="ghost" size="icon" className="h-8 w-8 rounded-md" onClick={() => onMonthChange(subMonths(currentMonth, 1))}>
+          <Button variant="ghost" size="icon" className="h-8 w-8 rounded-lg" onClick={() => onMonthChange(subMonths(currentMonth, 1))}>
             <ChevronLeft className="h-4 w-4" />
           </Button>
-          <Button variant="secondary" size="sm" className="h-8 rounded-md px-4" onClick={() => onMonthChange(new Date())}>
+          <Button variant="secondary" size="sm" className="h-8 rounded-lg px-4" onClick={() => onMonthChange(new Date())}>
             Hoy
           </Button>
-          <Button variant="ghost" size="icon" className="h-8 w-8 rounded-md" onClick={() => onMonthChange(addMonths(currentMonth, 1))}>
+          <Button variant="ghost" size="icon" className="h-8 w-8 rounded-lg" onClick={() => onMonthChange(addMonths(currentMonth, 1))}>
             <ChevronRight className="h-4 w-4" />
           </Button>
         </div>


### PR DESCRIPTION
## Summary

Applies the ADR-0016 rectangular radius system to all calendar components.

- Primary controls (prev/next month, Hoy, Expandir/Colapsar todas): use ounded-lg (6px base)
- Reservation bars: use ounded-m\l-sm\l-md via getContinuationRadiusClass
- Compact chips (billing type, booking source, overlay labels): use ounded-md
- Color swatches, today marker: keep ounded-full
- 22 tests added covering all radius scenarios

## Related

Closes #149