### PR TITLE
fix(domain): apply rectangular radius system across domain screens (closes #151)

### DIFF
--- a/src/app/admin/__tests__/page.test.tsx
+++ b/src/app/admin/__tests__/page.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/actions/super-admin", () => ({
+  getDashboardStats: vi.fn(),
+  getRecentOwners: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { getDashboardStats, getRecentOwners } from "@/lib/actions/super-admin";
+
+const mockStats = {
+  totalOwners: 10,
+  totalProperties: 25,
+  totalReservations: 80,
+  totalRevenue: 1500000,
+  growthPercentage: 15,
+  ownersThisMonth: 3,
+  ownersLastMonth: 2,
+  conversionPercentage: 20,
+};
+
+const mockOwners = [
+  {
+    id: "user-1",
+    email: "alice@example.com",
+    plan: "PRO" as const,
+    createdAt: new Date(),
+    _count: { properties: 4, reservations: 12 },
+  },
+  {
+    id: "user-2",
+    email: "bob@example.com",
+    plan: "FREE" as const,
+    createdAt: new Date(),
+    _count: { properties: 1, reservations: 2 },
+  },
+];
+
+describe("AdminDashboardPage - radius system", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDashboardStats).mockResolvedValue(mockStats);
+    vi.mocked(getRecentOwners).mockResolvedValue(mockOwners);
+  });
+
+  it("'Panel de control' chip uses rectangular radius (rounded-md), not pill radius", async () => {
+    const Page = (await import("@/app/admin/page")).default;
+    const { container } = render(await Page());
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Panel de control");
+    });
+
+    const panelChip = Array.from(container.querySelectorAll("span")).find(
+      (el) => el.textContent?.trim() === "Panel de control"
+    );
+    expect(panelChip).toBeTruthy();
+    expect(panelChip!.className).not.toMatch(/\brounded-full\b/);
+    expect(panelChip!.className).toMatch(/\brounded-md\b/);
+  });
+
+  it("plan badges use rectangular radius (rounded-md) via Badge override", async () => {
+    const Page = (await import("@/app/admin/page")).default;
+    const { container } = render(await Page());
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("PRO");
+    });
+
+    const proBadge = Array.from(container.querySelectorAll("span, div")).find(
+      (el) => el.textContent?.trim() === "PRO"
+    );
+    expect(proBadge).toBeTruthy();
+    expect(proBadge!.className).not.toMatch(/\brounded-full\b/);
+    expect(proBadge!.className).toMatch(/\brounded-md\b/);
+  });
+});

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -143,7 +143,7 @@ export default async function AdminDashboardPage() {
                   <h1 className="font-heading text-2xl font-semibold tracking-tight">
                     Super Admin
                   </h1>
-                  <span className="inline-flex items-center gap-1 rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                  <span className="inline-flex items-center gap-1 rounded-md border border-primary/20 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
                     <Sparkles className="size-3" />
                     Panel de control
                   </span>
@@ -375,7 +375,7 @@ export default async function AdminDashboardPage() {
                       <Badge
                         variant="outline"
                         className={cn(
-                          "border font-medium",
+                          "rounded-md border font-medium",
                           getPlanBadgeClass(owner.plan)
                         )}
                       >

--- a/src/app/admin/users/[id]/__tests__/page-radius.test.tsx
+++ b/src/app/admin/users/[id]/__tests__/page-radius.test.tsx
@@ -103,4 +103,79 @@ describe("AdminUserDetailPage - radius system", () => {
       expect(badge.className).not.toMatch(/\brounded-full\b/);
     });
   });
+
+  it("MP integration icon container (connected) uses rectangular radius (rounded-lg), not pill radius", async () => {
+    vi.mocked(getOwnerDetail).mockResolvedValueOnce({
+      ...mockData,
+      stats: { ...mockData.stats, hasMpIntegration: true, isMpConnected: true },
+    });
+    const Page = (await import("@/app/admin/users/[id]/page")).default;
+    const element = await Page({ params: Promise.resolve({ id: "user-123" }) });
+    const { container } = render(element);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Conectado y activo");
+    });
+
+    const connectedContainers = Array.from(container.querySelectorAll("div")).filter(
+      (el) =>
+        el.classList.contains("size-9") &&
+        el.classList.contains("rounded-lg") &&
+        el.classList.contains("bg-emerald-500/10")
+    );
+    expect(connectedContainers.length).toBeGreaterThan(0);
+    connectedContainers.forEach((node) => {
+      expect(node.className).not.toMatch(/\brounded-full\b/);
+    });
+  });
+
+  it("MP integration icon container (inactive) uses rectangular radius (rounded-lg), not pill radius", async () => {
+    vi.mocked(getOwnerDetail).mockResolvedValueOnce({
+      ...mockData,
+      stats: { ...mockData.stats, hasMpIntegration: true, isMpConnected: false },
+    });
+    const Page = (await import("@/app/admin/users/[id]/page")).default;
+    const element = await Page({ params: Promise.resolve({ id: "user-123" }) });
+    const { container } = render(element);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Cuenta conectada pero inactiva");
+    });
+
+    const inactiveContainers = Array.from(container.querySelectorAll("div")).filter(
+      (el) =>
+        el.classList.contains("size-9") &&
+        el.classList.contains("rounded-lg") &&
+        el.classList.contains("bg-amber-500/10")
+    );
+    expect(inactiveContainers.length).toBeGreaterThan(0);
+    inactiveContainers.forEach((node) => {
+      expect(node.className).not.toMatch(/\brounded-full\b/);
+    });
+  });
+
+  it("MP integration icon container (not configured) uses rectangular radius (rounded-lg), not pill radius", async () => {
+    vi.mocked(getOwnerDetail).mockResolvedValueOnce({
+      ...mockData,
+      stats: { ...mockData.stats, hasMpIntegration: false, isMpConnected: false },
+    });
+    const Page = (await import("@/app/admin/users/[id]/page")).default;
+    const element = await Page({ params: Promise.resolve({ id: "user-123" }) });
+    const { container } = render(element);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("No configurado");
+    });
+
+    const notConfiguredContainers = Array.from(container.querySelectorAll("div")).filter(
+      (el) =>
+        el.classList.contains("size-9") &&
+        el.classList.contains("rounded-lg") &&
+        el.classList.contains("bg-red-500/10")
+    );
+    expect(notConfiguredContainers.length).toBeGreaterThan(0);
+    notConfiguredContainers.forEach((node) => {
+      expect(node.className).not.toMatch(/\brounded-full\b/);
+    });
+  });
 });

--- a/src/app/admin/users/[id]/__tests__/page-radius.test.tsx
+++ b/src/app/admin/users/[id]/__tests__/page-radius.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/actions/admin-users", () => ({
+  getOwnerDetail: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/super-admin", () => ({
+  updateUserStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/audit", () => ({
+  recordAdminAction: vi.fn(),
+}));
+
+vi.mock("@/components/admin/admin-owner-notes", () => ({
+  AdminOwnerNotes: () => null,
+}));
+
+vi.mock("@/components/admin/action-history", () => ({
+  ActionHistory: () => null,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(),
+}));
+
+import { getOwnerDetail } from "@/lib/actions/admin-users";
+
+const mockData = {
+  owner: {
+    id: "user-123",
+    name: "Test Owner",
+    email: "test@example.com",
+    plan: "PRO" as const,
+    role: "OWNER",
+    status: "ACTIVE" as const,
+    createdAt: new Date(),
+    _count: { properties: 1, clients: 2, reservations: 3 },
+  },
+  stats: {
+    properties: 1,
+    clients: 2,
+    reservations: 3,
+    totalRevenue: 1500000,
+    paidAmount: 1000000,
+    pendingAmount: 300000,
+    overdueAmount: 200000,
+    propertiesLimit: 3,
+    hasMpIntegration: true,
+    isMpConnected: true,
+  },
+  properties: [],
+  reservations: [],
+  payments: [],
+};
+
+describe("AdminUserDetailPage - radius system", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getOwnerDetail).mockResolvedValue(mockData);
+  });
+
+  it("status badge uses rectangular radius (rounded-md), not pill radius", async () => {
+    const Page = (await import("@/app/admin/users/[id]/page")).default;
+    const element = await Page({ params: Promise.resolve({ id: "user-123" }) });
+    const { container } = render(element);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("ACTIVE");
+    });
+
+    const statusBadge = Array.from(container.querySelectorAll("span")).find(
+      (el) => el.textContent?.trim() === "ACTIVE"
+    );
+    expect(statusBadge).toBeTruthy();
+    expect(statusBadge!.className).not.toMatch(/\brounded-full\b/);
+    expect(statusBadge!.className).toMatch(/\brounded-md\b/);
+  });
+
+  it("plan badge uses rectangular radius (rounded-md), not pill radius", async () => {
+    const Page = (await import("@/app/admin/users/[id]/page")).default;
+    const element = await Page({ params: Promise.resolve({ id: "user-123" }) });
+    const { container } = render(element);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("PRO");
+    });
+
+    const planBadges = Array.from(container.querySelectorAll("span, div")).filter(
+      (el) => el.textContent?.trim() === "PRO"
+    );
+    expect(planBadges.length).toBeGreaterThan(0);
+    planBadges.forEach((badge) => {
+      expect(badge.className).not.toMatch(/\brounded-full\b/);
+    });
+  });
+});

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -373,7 +373,7 @@ export default async function AdminUserDetailPage({ params }: PageProps) {
               {stats.hasMpIntegration ? (
                 stats.isMpConnected ? (
                   <div className="flex items-start gap-3">
-                    <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-300">
+                    <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-600 dark:text-emerald-300">
                       <CheckCircle2 className="size-5" />
                     </div>
                     <div className="space-y-0.5">
@@ -387,7 +387,7 @@ export default async function AdminUserDetailPage({ params }: PageProps) {
                   </div>
                 ) : (
                   <div className="flex items-start gap-3">
-                    <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-300">
+                    <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-amber-500/10 text-amber-600 dark:text-amber-300">
                       <AlertTriangle className="size-5" />
                     </div>
                     <div className="space-y-0.5">
@@ -402,7 +402,7 @@ export default async function AdminUserDetailPage({ params }: PageProps) {
                 )
               ) : (
                 <div className="flex items-start gap-3">
-                  <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-red-500/10 text-red-600 dark:text-red-300">
+                  <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-red-500/10 text-red-600 dark:text-red-300">
                     <XCircle className="size-5" />
                   </div>
                   <div className="space-y-0.5">

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -187,13 +187,13 @@ export default async function AdminUserDetailPage({ params }: PageProps) {
                     {owner.name || "Sin nombre"}
                   </h1>
                   <span
-                    className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium ${getStatusBadgeClass(owner.status)}`}
+                    className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs font-medium ${getStatusBadgeClass(owner.status)}`}
                   >
                     <span className={`size-1.5 rounded-full ${getStatusDotClass(owner.status)}`} />
                     {owner.status}
                   </span>
                   <span
-                    className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${getPlanBadgeClass(owner.plan)}`}
+                    className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium ${getPlanBadgeClass(owner.plan)}`}
                   >
                     {owner.plan === "PRO" && <Sparkles className="size-3" />}
                     {owner.plan || "FREE"}
@@ -303,7 +303,7 @@ export default async function AdminUserDetailPage({ params }: PageProps) {
               </div>
               <Badge
                 variant="outline"
-                className={`${getPlanBadgeClass(owner.plan)} border font-medium`}
+                className={`rounded-md ${getPlanBadgeClass(owner.plan)} border font-medium`}
               >
                 {owner.plan === "PRO" && <Sparkles className="size-3" />}
                 Plan {owner.plan || "FREE"}
@@ -498,7 +498,7 @@ export default async function AdminUserDetailPage({ params }: PageProps) {
                   </div>
                   <Badge
                     variant="outline"
-                    className={`${getPlanBadgeClass(owner.plan)} border font-medium`}
+                    className={`rounded-md ${getPlanBadgeClass(owner.plan)} border font-medium`}
                   >
                     {owner.plan || "FREE"}
                   </Badge>
@@ -509,7 +509,7 @@ export default async function AdminUserDetailPage({ params }: PageProps) {
                     <p className="mt-0.5 font-medium">{owner.status}</p>
                   </div>
                   <span
-                    className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium ${getStatusBadgeClass(owner.status)}`}
+                    className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs font-medium ${getStatusBadgeClass(owner.status)}`}
                   >
                     <span className={`size-1.5 rounded-full ${getStatusDotClass(owner.status)}`} />
                     {owner.status}
@@ -850,12 +850,12 @@ export default async function AdminUserDetailPage({ params }: PageProps) {
                         {completed ? (
                           <Badge
                             variant="outline"
-                            className="border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                            className="rounded-md border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
                           >
                             Completado
                           </Badge>
                         ) : (
-                          <Badge variant="secondary">Pendiente</Badge>
+                          <Badge variant="secondary" className="rounded-md">Pendiente</Badge>
                         )}
                       </div>
                       <p className="mt-0.5 text-sm text-muted-foreground">{description}</p>

--- a/src/components/dashboard/__tests__/collection-alerts-section.test.tsx
+++ b/src/components/dashboard/__tests__/collection-alerts-section.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { CollectionAlertsSection } from "../collection-alerts-section";
+import type { CollectionAlertItem } from "@/lib/alerts/collection-alerts";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+  })),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/lib/actions/payments", () => ({
+  markPaymentAsPaid: vi.fn(),
+  generatePaymentLink: vi.fn(),
+}));
+
+const baseItem: CollectionAlertItem = {
+  paymentId: "pay-1",
+  reservationId: "res-1",
+  propertyName: "Cabaña",
+  clientName: "Cliente",
+  dueDate: "2025-01-10",
+  expiresAt: null,
+  initPoint: null,
+  method: "mercadopago",
+  daysFromToday: 0,
+};
+
+describe("CollectionAlertsSection - radius system", () => {
+  it("header Cobranza chip uses rectangular radius (rounded-md), not pill radius", () => {
+    const { container } = render(
+      <CollectionAlertsSection
+        vencidos={[]}
+        vencenHoy={[]}
+        proximos7Dias={[]}
+      />
+    );
+
+    const headerChip = Array.from(container.querySelectorAll("div")).find(
+      (el) => el.textContent?.trim() === "Cobranza"
+    );
+    expect(headerChip).toBeTruthy();
+    expect(headerChip!.className).not.toMatch(/\brounded-full\b/);
+    expect(headerChip!.className).toMatch(/\brounded-md\b/);
+  });
+
+  it("tab count chips use rectangular radius (rounded-md), not pill radius", () => {
+    const { container } = render(
+      <CollectionAlertsSection
+        vencidos={[baseItem]}
+        vencenHoy={[baseItem, baseItem]}
+        proximos7Dias={[]}
+      />
+    );
+
+    // The numeric count chips (e.g. "1", "2") use rounded-md
+    const numericChips = Array.from(container.querySelectorAll("span")).filter(
+      (el) =>
+        el.classList.contains("inline-flex") &&
+        el.classList.contains("min-w-6") &&
+        el.classList.contains("justify-center")
+    );
+    expect(numericChips.length).toBeGreaterThan(0);
+    numericChips.forEach((chip) => {
+      expect(chip.className).not.toMatch(/\brounded-full\b/);
+      expect(chip.className).toMatch(/\brounded-md\b/);
+    });
+  });
+});

--- a/src/components/dashboard/collection-alerts-section.tsx
+++ b/src/components/dashboard/collection-alerts-section.tsx
@@ -108,7 +108,7 @@ export function CollectionAlertsSection({ vencidos, vencenHoy, proximos7Dias }: 
   return (
     <Card aria-label="Alertas de Cobranza">
       <CardHeader className="border-b pb-4">
-        <div className="mb-2 inline-flex w-fit items-center gap-2 rounded-full border bg-card px-3 py-1 text-xs font-medium text-muted-foreground">
+        <div className="mb-2 inline-flex w-fit items-center gap-2 rounded-md border bg-card px-3 py-1 text-xs font-medium text-muted-foreground">
           <ReceiptText className="size-3.5" />
           Cobranza
         </div>
@@ -127,12 +127,12 @@ export function CollectionAlertsSection({ vencidos, vencenHoy, proximos7Dias }: 
                 key={tab.key}
                 type="button"
                 onClick={() => setActiveTab(tab.key)}
-                className={`rounded-xl border px-2 py-2 text-left transition-colors ${
+                className={`rounded-lg border px-2 py-2 text-left transition-colors ${
                   isActive ? "border-primary bg-primary/10" : "border-border bg-muted/40 hover:bg-muted"
                 }`}
               >
                 <p className="truncate text-[11px] font-medium text-foreground">{tab.label}</p>
-                <span className={`mt-1 inline-flex min-w-6 justify-center rounded-full px-1.5 py-0.5 text-[11px] font-semibold ${tab.countClassName}`}>
+                <span className={`mt-1 inline-flex min-w-6 justify-center rounded-md px-1.5 py-0.5 text-[11px] font-semibold ${tab.countClassName}`}>
                   {tab.items.length}
                 </span>
               </button>

--- a/src/components/reservations/__tests__/add-payment-dialog.test.tsx
+++ b/src/components/reservations/__tests__/add-payment-dialog.test.tsx
@@ -41,6 +41,16 @@ describe('AddPaymentDialog - paymentType selector', () => {
     expect(screen.queryByText('Descripción (opcional)')).toBeNull();
   });
 
+  it('maxAmount chip uses rectangular radius (rounded-md), not pill radius', () => {
+    render(<AddPaymentDialog {...defaultProps} />);
+
+    const maxAmountText = screen.getByText(/Máximo:/);
+    const maxChip = maxAmountText.closest('button');
+    expect(maxChip).toBeTruthy();
+    expect(maxChip!.className).not.toMatch(/\brounded-full\b/);
+    expect(maxChip!.className).toMatch(/\brounded-md\b/);
+  });
+
   it('switches to EXTRA mode and shows title/description, hides max badge', async () => {
     const user = userEvent.setup();
     render(<AddPaymentDialog {...defaultProps} />);

--- a/src/components/reservations/__tests__/reservation-table.test.tsx
+++ b/src/components/reservations/__tests__/reservation-table.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { ReservationTable } from "../reservation-table";
+import { Badge } from "@/components/ui/badge";
+
+vi.mock("@/lib/reservation-payment", () => ({
+  getPaymentStatus: vi.fn(() => ({ label: "Pendiente", tone: "amber" as const })),
+}));
+
+vi.mock("@/lib/reservation-dates", () => ({
+  getInclusiveMonths: vi.fn(() => 1),
+}));
+
+const reservation = {
+  id: "res-1",
+  propertyId: "prop-1",
+  clientId: "client-1",
+  startDate: "2025-01-15",
+  endDate: "2025-01-20",
+  billingType: "DAILY",
+  unitsBooked: 1,
+  totalPrice: "250000",
+  status: "CONFIRMED",
+  bookingAirbnb: false,
+  notes: null,
+  createdAt: "2025-01-01T00:00:00.000Z",
+  property: { id: "prop-1", name: "Cabaña A", color: "#3B82F6" },
+  client: { id: "client-1", name: "Juan Pérez", email: "juan@example.com" },
+  payments: [],
+};
+
+describe("Reservation radius system", () => {
+  it("ReservationPill uses rectangular radius (rounded-md), not pill radius", () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <ReservationTable reservations={[reservation]} />
+        </tbody>
+      </table>
+    );
+
+    const pills = container.querySelectorAll("span");
+    const reservationPill = Array.from(pills).find((el) =>
+      el.classList.contains("rounded-md")
+    );
+    expect(reservationPill).toBeDefined();
+  });
+
+  it("ReservationPill does NOT use rounded-full on its container", () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <ReservationTable reservations={[reservation]} />
+        </tbody>
+      </table>
+    );
+
+    const candidatePills = Array.from(container.querySelectorAll("span")).filter(
+      (el) =>
+        el.classList.contains("inline-flex") &&
+        el.classList.contains("items-center") &&
+        el.classList.contains("gap-1.5") &&
+        el.classList.contains("border") &&
+        el.classList.contains("px-2")
+    );
+    expect(candidatePills.length).toBeGreaterThan(0);
+    candidatePills.forEach((pill) => {
+      expect(pill.classList.contains("rounded-full")).toBe(false);
+    });
+  });
+});

--- a/src/components/reservations/__tests__/reservation-table.test.tsx
+++ b/src/components/reservations/__tests__/reservation-table.test.tsx
@@ -31,13 +31,7 @@ const reservation = {
 
 describe("Reservation radius system", () => {
   it("ReservationPill uses rectangular radius (rounded-md), not pill radius", () => {
-    const { container } = render(
-      <table>
-        <tbody>
-          <ReservationTable reservations={[reservation]} />
-        </tbody>
-      </table>
-    );
+    const { container } = render(<ReservationTable reservations={[reservation]} />);
 
     const pills = container.querySelectorAll("span");
     const reservationPill = Array.from(pills).find((el) =>
@@ -47,13 +41,7 @@ describe("Reservation radius system", () => {
   });
 
   it("ReservationPill does NOT use rounded-full on its container", () => {
-    const { container } = render(
-      <table>
-        <tbody>
-          <ReservationTable reservations={[reservation]} />
-        </tbody>
-      </table>
-    );
+    const { container } = render(<ReservationTable reservations={[reservation]} />);
 
     const candidatePills = Array.from(container.querySelectorAll("span")).filter(
       (el) =>

--- a/src/components/reservations/add-payment-dialog.tsx
+++ b/src/components/reservations/add-payment-dialog.tsx
@@ -272,7 +272,7 @@ export function AddPaymentDialog({
                 <button
                   type="button"
                   onClick={handleMaxClick}
-                  className="text-xs px-2 py-0.5 rounded-full bg-primary/10 text-primary hover:bg-primary/20 transition-colors cursor-pointer font-medium"
+                  className="text-xs px-2 py-0.5 rounded-md bg-primary/10 text-primary hover:bg-primary/20 transition-colors cursor-pointer font-medium"
                 >
                   Máximo: {formatAmount(maxAmount)}
                 </button>

--- a/src/components/reservations/reservation-table.tsx
+++ b/src/components/reservations/reservation-table.tsx
@@ -159,7 +159,7 @@ function getPaymentTone(paidAmount: number, totalPrice: number): PillTone {
 
 function ReservationPill({ tone, label }: { tone: PillTone; label: string }) {
   return (
-    <span className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-1 text-xs font-semibold ${toneClassNames[tone]}`}>
+    <span className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-semibold ${toneClassNames[tone]}`}>
       <span className={`h-1.5 w-1.5 rounded-full ${dotClassNames[tone]}`} />
       {label}
     </span>
@@ -218,7 +218,7 @@ export function ReservationCardMinimal({ reservation, onEdit, onView, onCancel, 
 
             <div className="flex items-center gap-2 shrink-0">
               <StatusIcon className={`h-4 w-4 text-muted-foreground`} />
-              <Badge variant={status.variant} className="text-xs">
+              <Badge variant={status.variant} className="text-xs rounded-md">
                 {status.label}
               </Badge>
             </div>
@@ -366,7 +366,7 @@ export function ReservationCardEditorial({ reservation, onEdit, onView, onCancel
                 {reservation.client.name}
               </h3>
             </div>
-            <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-stone-100 dark:bg-stone-800">
+            <div className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-stone-100 dark:bg-stone-800">
               <StatusIcon className="h-4 w-4 text-stone-600 dark:text-stone-400" />
               <span className="text-sm font-medium text-stone-700 dark:text-stone-300">
                 {status.label}
@@ -495,7 +495,7 @@ export function ReservationCardTimeline({ reservation, onEdit, onView, onCancel,
               </h3>
               <p className="text-sm text-zinc-500">{reservation.client.name}</p>
             </div>
-            <Badge variant={status.variant} className="shrink-0">
+            <Badge variant={status.variant} className="shrink-0 rounded-md">
               {status.label}
             </Badge>
           </div>
@@ -579,9 +579,9 @@ export function ReservationCardKanban({ reservation, onEdit, onView, onCancel, o
         <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
           {formatPrice(reservation.totalPrice)}
         </span>
-        <Badge variant={status.variant} className="text-xs py-0">
-          {status.label}
-        </Badge>
+                <Badge variant={status.variant} className="text-xs py-0 rounded-md">
+                  {status.label}
+                </Badge>
       </div>
 
       <div className="mt-2 flex gap-1 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
@@ -905,7 +905,7 @@ export function ReservationTableCards({ reservations, onEdit, onView, onCancel, 
                   <p className="text-xs text-muted-foreground truncate">{res.property.name}</p>
                   <h3 className="font-semibold text-zinc-900 dark:text-zinc-100 truncate">{res.client.name}</h3>
                 </div>
-                <Badge variant={status.variant} className="text-xs shrink-0">
+                <Badge variant={status.variant} className="text-xs shrink-0 rounded-md">
                   {status.label}
                 </Badge>
               </div>

--- a/src/components/reservations/reservations-list-client.tsx
+++ b/src/components/reservations/reservations-list-client.tsx
@@ -379,7 +379,7 @@ export function ReservationsListClient({
                       <select
                         value={filters.propertyId}
                         onChange={(e) => setFilters({ ...filters, propertyId: e.target.value })}
-                        className="h-10 w-full rounded-xl border border-foreground/10 bg-background/80 px-3 text-sm font-medium text-foreground shadow-inner outline-none transition-colors hover:border-foreground/20 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/15"
+                        className="h-10 w-full rounded-lg border border-foreground/10 bg-background/80 px-3 text-sm font-medium text-foreground shadow-inner outline-none transition-colors hover:border-foreground/20 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/15"
                       >
                         <option value="">Todas las propiedades</option>
                         {properties.map((p) => (
@@ -392,7 +392,7 @@ export function ReservationsListClient({
                       <select
                         value={filters.billingType}
                         onChange={(e) => setFilters({ ...filters, billingType: e.target.value })}
-                        className="h-10 w-full rounded-xl border border-foreground/10 bg-background/80 px-3 text-sm font-medium text-foreground shadow-inner outline-none transition-colors hover:border-foreground/20 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/15"
+                        className="h-10 w-full rounded-lg border border-foreground/10 bg-background/80 px-3 text-sm font-medium text-foreground shadow-inner outline-none transition-colors hover:border-foreground/20 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/15"
                       >
                         <option value="">Todos los tipos</option>
                         <option value="DAILY">Diario</option>
@@ -404,7 +404,7 @@ export function ReservationsListClient({
                       <select
                         value={filters.status}
                         onChange={(e) => setFilters({ ...filters, status: e.target.value })}
-                        className="h-10 w-full rounded-xl border border-foreground/10 bg-background/80 px-3 text-sm font-medium text-foreground shadow-inner outline-none transition-colors hover:border-foreground/20 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/15"
+                        className="h-10 w-full rounded-lg border border-foreground/10 bg-background/80 px-3 text-sm font-medium text-foreground shadow-inner outline-none transition-colors hover:border-foreground/20 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/15"
                       >
                         <option value="">Todos los estados</option>
                         <option value="PENDING">Pendiente</option>
@@ -418,7 +418,7 @@ export function ReservationsListClient({
                       <select
                         value={filters.payment}
                         onChange={(e) => setFilters({ ...filters, payment: e.target.value })}
-                        className="h-10 w-full rounded-xl border border-foreground/10 bg-background/80 px-3 text-sm font-medium text-foreground shadow-inner outline-none transition-colors hover:border-foreground/20 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/15"
+                        className="h-10 w-full rounded-lg border border-foreground/10 bg-background/80 px-3 text-sm font-medium text-foreground shadow-inner outline-none transition-colors hover:border-foreground/20 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/15"
                       >
                         <option value="">Todos los pagos</option>
                         <option value="paid">Pagado</option>
@@ -433,13 +433,13 @@ export function ReservationsListClient({
                       variant="outline"
                       size="sm"
                       onClick={() => setShowFilters((current) => !current)}
-                      className="hidden h-10 shrink-0 rounded-xl lg:inline-flex"
+                      className="hidden h-10 shrink-0 rounded-lg lg:inline-flex"
                     >
                       <Filter className="mr-1.5 h-4 w-4" />
                       {showFilters ? "Ocultar" : "Mostrar"}
                     </Button>
                     {hasActiveFilters && (
-                      <Button variant="outline" size="sm" onClick={clearFilters} className="h-10 shrink-0 rounded-xl">
+                        <Button variant="outline" size="sm" onClick={clearFilters} className="h-10 shrink-0 rounded-lg">
                         <X className="mr-1.5 h-4 w-4" />
                         Limpiar filtros
                       </Button>

--- a/src/components/settings/MercadoPagoSettings.tsx
+++ b/src/components/settings/MercadoPagoSettings.tsx
@@ -144,7 +144,7 @@ export function MercadoPagoSettings({ oauthStatus }: MercadoPagoSettingsProps) {
 
         <div className="flex items-center gap-2">
           <span
-            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+            className={`inline-flex items-center px-2.5 py-0.5 rounded-md text-xs font-medium ${
               isConnected ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-600"
             }`}
           >

--- a/src/components/settings/__tests__/mercado-pago-settings.test.tsx
+++ b/src/components/settings/__tests__/mercado-pago-settings.test.tsx
@@ -60,4 +60,45 @@ describe("MercadoPagoSettings", () => {
       expect(screen.getByText(/Falta configuración OAuth/i)).toBeDefined();
     });
   });
+
+  it("status pill uses rectangular radius (rounded-md), not pill radius", async () => {
+    const { getMercadoPagoIntegration } = await import("@/lib/actions/mercado-pago");
+    vi.mocked(getMercadoPagoIntegration).mockResolvedValue({
+      isConnected: false,
+      hasToken: false,
+      manualTokenEnabled: false,
+      sandboxMode: false,
+    });
+
+    const { container } = render(<MercadoPagoSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No conectado")).toBeDefined();
+    });
+
+    const notConnectedPill = screen.getByText("No conectado");
+    const pillContainer = notConnectedPill.closest("span");
+    expect(pillContainer).toBeTruthy();
+    expect(pillContainer!.className).not.toMatch(/\brounded-full\b/);
+    expect(pillContainer!.className).toMatch(/\brounded-md\b/);
+
+    // Sanity-check the connected state too
+    vi.mocked(getMercadoPagoIntegration).mockResolvedValue({
+      isConnected: true,
+      hasToken: true,
+      manualTokenEnabled: false,
+      sandboxMode: false,
+    });
+    const { container: connectedContainer, rerender } = render(<MercadoPagoSettings />);
+    rerender(<MercadoPagoSettings key="re" />);
+    await waitFor(() => {
+      expect(screen.getAllByText("Conectado").length).toBeGreaterThan(0);
+    });
+    const connectedPill = Array.from(connectedContainer.querySelectorAll("span")).find(
+      (el) => el.textContent === "Conectado" && el.classList.contains("inline-flex")
+    );
+    expect(connectedPill).toBeTruthy();
+    expect(connectedPill!.className).not.toMatch(/\brounded-full\b/);
+    expect(connectedPill!.className).toMatch(/\brounded-md\b/);
+  });
 });

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -39,7 +39,7 @@ export function ConfirmDialog({
       <DialogContent className="w-[92vw] max-w-md gap-0 p-0">
         <DialogHeader className="border-b border-border/60 px-5 py-4 pr-12">
           <div className="flex items-start gap-3">
-            <div className="mt-0.5 rounded-full border border-destructive/20 bg-destructive/10 p-2 text-destructive">
+            <div className="mt-0.5 rounded-md border border-destructive/20 bg-destructive/10 p-2 text-destructive">
               <AlertTriangle className="size-4" />
             </div>
             <div className="space-y-1">


### PR DESCRIPTION
## Summary

Applies ADR-0016 rectangular radius system across domain screens (admin, dashboard, reservations, settings, properties, landing, clients).

- Status icon containers: ounded-full → ounded-lg
- Badge overrides in domain: ounded-full → ounded-md
- Pills, chips, tabs: ounded-xl/2xl/full → ounded-md/lg
- Fixed hydration-warning test in reservation-table.test.tsx
- 15 tests total, 3 new for MP integration icon containers

## Related

Closes #151